### PR TITLE
update to mongo driver 2.2.3

### DIFF
--- a/MongoDBIntIDGenerator.Tests/Int32IdGeneratorLegacyTest.cs
+++ b/MongoDBIntIDGenerator.Tests/Int32IdGeneratorLegacyTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MongoDB.Driver;
+using NUnit.Framework;
+using MongoDBIntIdGenerator.Tests.Stubs;
+
+namespace MongoDBIntIdGenerator.Tests
+{
+    [TestFixture]
+    public class Int32IdGeneratorLegacyTest
+    {
+        private MongoDatabase _db;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+			_db = new MongoClient("mongodb://localhost/?safe=true")
+                .GetServer()
+                .GetDatabase("test");
+
+			// Keep the collection clear for the tests.
+			_db.GetCollection ("IdInt32").RemoveAll ();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _db.Drop();
+        }
+
+        [Test]
+        public void Saving_Item_Has_Id_Of_1()
+        {
+            var item = new StubInt32EntityLegacy { Name = "Testing" };
+
+            _db.GetCollection<StubInt32EntityLegacy>("testEntities").Save(item);
+
+            Assert.AreEqual(1, item.Id);
+        }
+
+        [Test]
+        public void When_Saving_2_Items_Second_Item_Has_Id_Of_2()
+        {
+            var item1 = new StubInt32EntityLegacy { Name = "Testing" };
+            var item2 = new StubInt32EntityLegacy { Name = "Testing 2" };
+
+            _db.GetCollection<StubInt32EntityLegacy>("testEntities").Save(item1);
+            _db.GetCollection<StubInt32EntityLegacy>("testEntities").Save(item2);
+
+            Assert.AreEqual(2, item2.Id);
+        }
+
+        [Test]
+        public void Save_Batch_Of_Items()
+        {
+            var items = new List<StubInt32EntityLegacy>();
+
+            for (int i = 0; i < 1000; i++)
+                items.Add(new StubInt32EntityLegacy { Name = "Item " + i });
+
+            _db.GetCollection<StubInt32EntityLegacy>("testEntities").InsertBatch(items);
+
+            for (var i = 1; i < 1001; i++)
+                Assert.That(items.Select(x => x.Id).Contains(i));
+        }
+    }
+}

--- a/MongoDBIntIDGenerator.Tests/Int32IdGeneratorTest.cs
+++ b/MongoDBIntIDGenerator.Tests/Int32IdGeneratorTest.cs
@@ -5,29 +5,30 @@ using System.Text;
 using MongoDB.Driver;
 using NUnit.Framework;
 using MongoDBIntIdGenerator.Tests.Stubs;
+using MongoDB.Bson;
 
 namespace MongoDBIntIdGenerator.Tests
 {
     [TestFixture]
     public class Int32IdGeneratorTest
     {
-        private MongoDatabase _db;
+        private IMongoDatabase _db;
+        private MongoClient _client;
 
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
-			_db = new MongoClient("mongodb://localhost/?safe=true")
-                .GetServer()
-                .GetDatabase("test");
+            _client = new MongoClient("mongodb://localhost/?safe=true");
+            _db = _client.GetDatabase("test");
 
 			// Keep the collection clear for the tests.
-			_db.GetCollection ("IdInt32").RemoveAll ();
+			_db.GetCollection<BsonDocument> ("IdInt32").DeleteMany(new BsonDocument());
         }
 
         [SetUp]
         public void SetUp()
         {
-            _db.Drop();
+            _client.DropDatabase("test");
         }
 
         [Test]
@@ -35,7 +36,7 @@ namespace MongoDBIntIdGenerator.Tests
         {
             var item = new StubInt32Entity { Name = "Testing" };
 
-            _db.GetCollection<StubInt32Entity>("testEntities").Save(item);
+            _db.GetCollection<StubInt32Entity>("testEntities").InsertOne(item);
 
             Assert.AreEqual(1, item.Id);
         }
@@ -46,8 +47,8 @@ namespace MongoDBIntIdGenerator.Tests
             var item1 = new StubInt32Entity { Name = "Testing" };
             var item2 = new StubInt32Entity { Name = "Testing 2" };
 
-            _db.GetCollection<StubInt32Entity>("testEntities").Save(item1);
-            _db.GetCollection<StubInt32Entity>("testEntities").Save(item2);
+            _db.GetCollection<StubInt32Entity>("testEntities").InsertOne(item1);
+            _db.GetCollection<StubInt32Entity>("testEntities").InsertOne(item2);
 
             Assert.AreEqual(2, item2.Id);
         }
@@ -60,7 +61,7 @@ namespace MongoDBIntIdGenerator.Tests
             for (int i = 0; i < 1000; i++)
                 items.Add(new StubInt32Entity { Name = "Item " + i });
 
-            _db.GetCollection<StubInt32Entity>("testEntities").InsertBatch(items);
+            _db.GetCollection<StubInt32Entity>("testEntities").InsertMany(items);
 
             for (var i = 1; i < 1001; i++)
                 Assert.That(items.Select(x => x.Id).Contains(i));

--- a/MongoDBIntIDGenerator.Tests/Int64IdGeneratorLegacyTest.cs
+++ b/MongoDBIntIDGenerator.Tests/Int64IdGeneratorLegacyTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MongoDB.Driver;
+using NUnit.Framework;
+using MongoDBIntIdGenerator.Tests.Stubs;
+
+namespace MongoDBIntIdGenerator.Tests
+{
+    [TestFixture]
+    public class Int64IdGeneratorLegacyTest
+    {
+        private MongoDatabase _db;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+			_db = new MongoClient("mongodb://localhost/?safe=true")
+				.GetServer()
+				.GetDatabase("test");
+
+			// Keep the collection clear for the tests.
+			_db.GetCollection ("IdInt64").RemoveAll ();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _db.Drop();
+        }
+
+        [Test]
+        public void Saving_Item_Has_Id_Of_1()
+        {
+            var item = new StubInt64EntityLegacy { Name = "Testing" };
+
+            _db.GetCollection<StubInt64EntityLegacy>("testEntities").Save(item);
+
+            Assert.AreEqual(1, item.Id);
+        }
+
+        [Test]
+        public void When_Saving_2_Items_Second_Item_Has_Id_Of_2()
+        {
+            var item1 = new StubInt64EntityLegacy { Name = "Testing" };
+            var item2 = new StubInt64EntityLegacy { Name = "Testing 2" };
+
+            _db.GetCollection<StubInt64EntityLegacy>("testEntities").Save(item1);
+            _db.GetCollection<StubInt64EntityLegacy>("testEntities").Save(item2);
+
+            Assert.AreEqual(2, item2.Id);
+        }
+
+        [Test]
+        public void Save_Batch_Of_Items()
+        {
+            var items = new List<StubInt64EntityLegacy>();
+
+            for (int i = 0; i < 1000; i++)
+                items.Add(new StubInt64EntityLegacy { Name = "Item " + i });
+
+            _db.GetCollection<StubInt64EntityLegacy>("testEntities").InsertBatch(items);
+
+            for (var i = 1; i < 1001; i++)
+                Assert.That(items.Select(x => x.Id).Contains(i));
+        }
+    }
+}

--- a/MongoDBIntIDGenerator.Tests/MongoDBIntIDGenerator.Tests.csproj
+++ b/MongoDBIntIDGenerator.Tests/MongoDBIntIDGenerator.Tests.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MongoDBIntIdGenerator.Tests</RootNamespace>
     <AssemblyName>MongoDBIntIdGenerator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,13 +33,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MongoDB.Bson">
-      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver">
-      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Legacy, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.2.2.3\lib\net45\MongoDB.Driver.Legacy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,11 +61,13 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Int32IdGeneratorTest.cs" />
+    <Compile Include="Int64IdGeneratorTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Stubs\StubInt32Entity.cs" />
     <Compile Include="Stubs\StubInt64Entity.cs" />
-    <Compile Include="Int32IdGeneratorTest.cs" />
-    <Compile Include="Int64IdGeneratorTest.cs" />
+    <Compile Include="Int32IdGeneratorLegacyTest.cs" />
+    <Compile Include="Int64IdGeneratorLegacyTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -72,5 +87,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/MongoDBIntIDGenerator.Tests/Stubs/StubInt32Entity.cs
+++ b/MongoDBIntIDGenerator.Tests/Stubs/StubInt32Entity.cs
@@ -3,9 +3,16 @@ using MongoDB.Bson;
 
 namespace MongoDBIntIdGenerator.Tests.Stubs
 {
-    public class StubInt32Entity
+    public class StubInt32EntityLegacy
     {
         [BsonId(IdGenerator = typeof(Int32IdGenerator))]
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class StubInt32Entity
+    {
+        [BsonId(IdGenerator = typeof(Int32IdGenerator<StubInt32Entity>))]
         public int Id { get; set; }
         public string Name { get; set; }
     }

--- a/MongoDBIntIDGenerator.Tests/Stubs/StubInt64Entity.cs
+++ b/MongoDBIntIDGenerator.Tests/Stubs/StubInt64Entity.cs
@@ -3,10 +3,17 @@ using MongoDB.Bson;
 
 namespace MongoDBIntIdGenerator.Tests.Stubs
 {
-	public class StubInt64Entity
+	public class StubInt64EntityLegacy
 	{
 		[BsonId(IdGenerator = typeof(Int64IdGenerator))]
 		public long Id { get; set; }
 		public string Name { get; set; }
-	}
+    }
+
+    public class StubInt64Entity
+    {
+        [BsonId(IdGenerator = typeof(Int64IdGenerator<StubInt64Entity>))]
+        public long Id { get; set; }
+        public string Name { get; set; }
+    }
 }

--- a/MongoDBIntIDGenerator.Tests/packages.config
+++ b/MongoDBIntIDGenerator.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.9.2" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Bson" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/MongoDBIntIDGenerator/Int32IdGenerator.cs
+++ b/MongoDBIntIDGenerator/Int32IdGenerator.cs
@@ -59,4 +59,59 @@ namespace MongoDBIntIdGenerator
 		}
 		#endregion
     }
+
+
+    /// <summary>
+    /// Int32 identifier generator.
+    /// </summary>
+    public class Int32IdGenerator<TDocument> : IntIdGeneratorBase<TDocument>
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int32IdGenerator"/> class.
+        /// </summary>
+        /// <param name="idCollectionName">Identifier collection name.</param>
+        public Int32IdGenerator(string idCollectionName) : base(idCollectionName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int32IdGenerator"/> class.
+        /// </summary>
+        public Int32IdGenerator() : base("IdInt32")
+        {
+        }
+        #endregion
+
+        #region implemented abstract members of IntIdGeneratorBase
+        /// <summary>
+        /// Creates the update builder.
+        /// </summary>
+        /// <returns>The update builder.</returns>
+        protected override UpdateDefinition<BsonDocument> CreateUpdateDefinition()
+        {
+            return Builders<BsonDocument>.Update.Inc(x=>x["seq"], 1);
+        }
+
+        /// <summary>
+        /// Converts to int.
+        /// </summary>
+        /// <returns>The to int.</returns>
+        /// <param name="value">Value.</param>
+        protected override object ConvertToInt(BsonValue value)
+        {
+            return value.AsInt32;
+        }
+
+        /// <summary>
+        /// Tests whether an Id is empty.
+        /// </summary>
+        /// <param name="id">The Id.</param>
+        /// <returns>True if the Id is empty.</returns>
+        public override bool IsEmpty(object id)
+        {
+            return (Int32)id == 0;
+        }
+        #endregion
+    }
 }

--- a/MongoDBIntIDGenerator/Int64IdGenerator.cs
+++ b/MongoDBIntIDGenerator/Int64IdGenerator.cs
@@ -1,61 +1,117 @@
 using System;
 using MongoDB.Bson;
 using MongoDB.Driver.Builders;
+using MongoDB.Driver;
 
 namespace MongoDBIntIdGenerator
 {
-	/// <summary>
-	/// Int64 identifier generator.
-	/// </summary>
-	public sealed class Int64IdGenerator : IntIdGeneratorBase
-	{
-		#region Constructors
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int64IdGenerator"/> class.
-		/// </summary>
-		/// <param name="idCollectionName">Identifier collection name.</param>
-		public Int64IdGenerator(string idCollectionName) : base(idCollectionName)
-		{
-		}
+    /// <summary>
+    /// Int64 identifier generator.
+    /// </summary>
+    public sealed class Int64IdGenerator : IntIdGeneratorBase
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int64IdGenerator"/> class.
+        /// </summary>
+        /// <param name="idCollectionName">Identifier collection name.</param>
+        public Int64IdGenerator(string idCollectionName) : base(idCollectionName)
+        {
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int64IdGenerator"/> class.
-		/// </summary>
-		public Int64IdGenerator() : base("IdInt64")
-		{
-		}
-		#endregion
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int64IdGenerator"/> class.
+        /// </summary>
+        public Int64IdGenerator() : base("IdInt64")
+        {
+        }
+        #endregion
 
-		#region implemented abstract members of IntIdGeneratorBase
-		/// <summary>
-		/// Creates the update builder.
-		/// </summary>
-		/// <returns>The update builder.</returns>
-		protected override UpdateBuilder CreateUpdateBuilder ()
-		{
-			return Update.Inc ("seq", 1L);
-		}
+        #region implemented abstract members of IntIdGeneratorBase
+        /// <summary>
+        /// Creates the update builder.
+        /// </summary>
+        /// <returns>The update builder.</returns>
+        protected override UpdateBuilder CreateUpdateBuilder()
+        {
+            return Update.Inc("seq", 1L);
+        }
 
-		/// <summary>
-		/// Converts to int.
-		/// </summary>
-		/// <returns>The to int.</returns>
-		/// <param name="value">Value.</param>
-		protected override object ConvertToInt (BsonValue value)
-		{
-			return value.AsInt64;
-		}
+        /// <summary>
+        /// Converts to int.
+        /// </summary>
+        /// <returns>The to int.</returns>
+        /// <param name="value">Value.</param>
+        protected override object ConvertToInt(BsonValue value)
+        {
+            return value.AsInt64;
+        }
 
-		/// <summary>
-		/// Tests whether an Id is empty.
-		/// </summary>
-		/// <param name="id">The Id.</param>
-		/// <returns>True if the Id is empty.</returns>
-		public override bool IsEmpty (object id)
-		{
-			return ((Int64)id) == 0;
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Tests whether an Id is empty.
+        /// </summary>
+        /// <param name="id">The Id.</param>
+        /// <returns>True if the Id is empty.</returns>
+        public override bool IsEmpty(object id)
+        {
+            return ((Int64)id) == 0;
+        }
+        #endregion
+    }
+
+
+    /// <summary>
+    /// Int64 identifier generator.
+    /// </summary>
+    public sealed class Int64IdGenerator<TDocument> : IntIdGeneratorBase<TDocument>
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int64IdGenerator"/> class.
+        /// </summary>
+        /// <param name="idCollectionName">Identifier collection name.</param>
+        public Int64IdGenerator(string idCollectionName) : base(idCollectionName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.Int64IdGenerator"/> class.
+        /// </summary>
+        public Int64IdGenerator() : base("IdInt64")
+        {
+        }
+        #endregion
+
+        #region implemented abstract members of IntIdGeneratorBase
+        /// <summary>
+        /// Creates the update builder.
+        /// </summary>
+        /// <returns>The update builder.</returns>
+        protected override UpdateDefinition<BsonDocument> CreateUpdateDefinition()
+        {
+            return Builders<BsonDocument>.Update.Inc(x => x["seq"], 1L);
+        }
+
+        /// <summary>
+        /// Converts to int.
+        /// </summary>
+        /// <returns>The to int.</returns>
+        /// <param name="value">Value.</param>
+        protected override object ConvertToInt(BsonValue value)
+        {
+            return value.AsInt64;
+        }
+
+        /// <summary>
+        /// Tests whether an Id is empty.
+        /// </summary>
+        /// <param name="id">The Id.</param>
+        /// <returns>True if the Id is empty.</returns>
+        public override bool IsEmpty(object id)
+        {
+            return ((Int64)id) == 0;
+        }
+        #endregion
+    }
 }
 

--- a/MongoDBIntIDGenerator/IntIdGeneratorBase.cs
+++ b/MongoDBIntIDGenerator/IntIdGeneratorBase.cs
@@ -6,76 +6,150 @@ using MongoDB.Bson.Serialization;
 
 namespace MongoDBIntIdGenerator
 {
-	/// <summary>
-	/// Base class for id generator based on integer values.
-	/// </summary>
-	public abstract class IntIdGeneratorBase : IIdGenerator
-	{
-		#region Fields
-		private string m_idCollectionName;
-		#endregion
+    /// <summary>
+    /// Base class for id generator based on integer values.
+    /// </summary>
+    public abstract class IntIdGeneratorBase : IIdGenerator
+    {
+        #region Fields
+        private string m_idCollectionName;
+        #endregion
 
-		#region Constructors
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.IntIdGeneratorBase"/> class.
-		/// </summary>
-		/// <param name="idCollectionName">Identifier collection name.</param>
-		protected IntIdGeneratorBase(string idCollectionName)
-		{
-			m_idCollectionName = idCollectionName;
-		}
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.IntIdGeneratorBase"/> class.
+        /// </summary>
+        /// <param name="idCollectionName">Identifier collection name.</param>
+        protected IntIdGeneratorBase(string idCollectionName)
+        {
+            m_idCollectionName = idCollectionName;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.IntIdGeneratorBase"/> class.
-		/// </summary>
-		protected IntIdGeneratorBase() : this("IDs")
-		{
-		}
-		#endregion
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.IntIdGeneratorBase"/> class.
+        /// </summary>
+        protected IntIdGeneratorBase() : this("IDs")
+        {
+        }
+        #endregion
 
-		#region Methods
-		/// <summary>
-		/// Creates the update builder.
-		/// </summary>
-		/// <returns>The update builder.</returns>
-		protected abstract UpdateBuilder CreateUpdateBuilder ();
+        #region Methods
+        /// <summary>
+        /// Creates the update builder.
+        /// </summary>
+        /// <returns>The update builder.</returns>
+        protected abstract UpdateBuilder CreateUpdateBuilder();
 
-		/// <summary>
-		/// Converts to int.
-		/// </summary>
-		/// <returns>The to int.</returns>
-		/// <param name="value">Value.</param>
-		protected abstract object ConvertToInt (BsonValue value);
+        /// <summary>
+        /// Converts to int.
+        /// </summary>
+        /// <returns>The to int.</returns>
+        /// <param name="value">Value.</param>
+        protected abstract object ConvertToInt(BsonValue value);
 
-		/// <summary>
-		/// Tests whether an Id is empty.
-		/// </summary>
-		/// <param name="id">The Id.</param>
-		/// <returns>True if the Id is empty.</returns>
-		public abstract bool IsEmpty (object id);
+        /// <summary>
+        /// Tests whether an Id is empty.
+        /// </summary>
+        /// <param name="id">The Id.</param>
+        /// <returns>True if the Id is empty.</returns>
+        public abstract bool IsEmpty(object id);
 
-		/// <summary>
-		/// Generates an Id for a document.
-		/// </summary>
-		/// <param name="container">The container of the document (will be a MongoCollection when called from the C# driver).</param>
-		/// <param name="document">The document.</param>
-		/// <returns>An Id.</returns>
-		public object GenerateId(object container, object document)
-		{
-			var idSequenceCollection = ((MongoCollection)container).Database
-				.GetCollection(m_idCollectionName);
+        /// <summary>
+        /// Generates an Id for a document.
+        /// </summary>
+        /// <param name="container">The container of the document (will be a MongoCollection when called from the C# driver).</param>
+        /// <param name="document">The document.</param>
+        /// <returns>An Id.</returns>
+        public object GenerateId(object container, object document)
+        {
+            var idSequenceCollection = ((MongoCollection)container).Database
+                .GetCollection(m_idCollectionName);
 
-			var query = Query.EQ("_id", ((MongoCollection)container).Name);
+            var query = Query.EQ("_id", ((MongoCollection)container).Name);
 
-			return ConvertToInt(idSequenceCollection.FindAndModify(new FindAndModifyArgs()
-            		{
-		                Query = query,
-		                Update = CreateUpdateBuilder(),
-		                VersionReturned = FindAndModifyDocumentVersion.Modified,
-		                Upsert = true
-            		}).ModifiedDocument["seq"]);              
-		}
-		#endregion
-	}
+            return ConvertToInt(idSequenceCollection.FindAndModify(new FindAndModifyArgs()
+            {
+                Query = query,
+                Update = CreateUpdateBuilder(),
+                VersionReturned = FindAndModifyDocumentVersion.Modified,
+                Upsert = true
+            }).ModifiedDocument["seq"]);
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Base class for id generator based on integer values.
+    /// </summary>
+    public abstract class IntIdGeneratorBase<TDocument> : IIdGenerator
+    {
+        #region Fields
+        private string m_idCollectionName;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.IntIdGeneratorBase"/> class.
+        /// </summary>
+        /// <param name="idCollectionName">Identifier collection name.</param>
+        protected IntIdGeneratorBase(string idCollectionName)
+        {
+            m_idCollectionName = idCollectionName;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoDBIntIdGenerator.IntIdGeneratorBase"/> class.
+        /// </summary>
+        protected IntIdGeneratorBase() : this("IDs")
+        {
+        }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Creates the update builder.
+        /// </summary>
+        /// <returns>The update builder.</returns>
+        protected abstract UpdateDefinition<BsonDocument> CreateUpdateDefinition();
+
+        /// <summary>
+        /// Converts to int.
+        /// </summary>
+        /// <returns>The to int.</returns>
+        /// <param name="value">Value.</param>
+        protected abstract object ConvertToInt(BsonValue value);
+
+        /// <summary>
+        /// Tests whether an Id is empty.
+        /// </summary>
+        /// <param name="id">The Id.</param>
+        /// <returns>True if the Id is empty.</returns>
+        public abstract bool IsEmpty(object id);
+
+        /// <summary>
+        /// Generates an Id for a document.
+        /// </summary>
+        /// <param name="container">The container of the document (will be a MongoCollection when called from the C# driver).</param>
+        /// <param name="document">The document.</param>
+        /// <returns>An Id.</returns>
+        public object GenerateId(object container, object document)
+        {
+            var collection = ((IMongoCollection<TDocument>)container);
+            var idSequenceCollection = collection.Database
+                .GetCollection<BsonDocument>(m_idCollectionName);
+
+            var query = Builders<BsonDocument>.Filter.Eq("_id", collection.CollectionNamespace.CollectionName);
+
+            return ConvertToInt(idSequenceCollection.FindOneAndUpdate(
+                query,
+                CreateUpdateDefinition(),
+                new FindOneAndUpdateOptions<BsonDocument>()
+                {
+                    IsUpsert = true,
+                    ReturnDocument = ReturnDocument.After
+                })["seq"]);
+        }
+        #endregion
+    }
 }
 

--- a/MongoDBIntIDGenerator/MongoDBIntIDGenerator.csproj
+++ b/MongoDBIntIDGenerator/MongoDBIntIDGenerator.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MongoDBIntIdGenerator</RootNamespace>
     <AssemblyName>MongoDBIntIDGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,6 +27,7 @@
     <GenerateDocumentation>true</GenerateDocumentation>
     <DocumentationFile>bin\Debug\MongoDBIntIdGenerator.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,13 +36,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MongoDB.Bson">
-      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver">
-      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Legacy, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.2.2.3\lib\net45\MongoDB.Driver.Legacy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/MongoDBIntIDGenerator/packages.config
+++ b/MongoDBIntIDGenerator/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.9.2" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Bson" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I've done the same job has sharnol did..
- updated mongo to v2.2.3
- fw update to 4.5 (minimum required by the driver)
- update to the tests
- mantained backward compatibility to the legacy driver (and tests as well)

Here an explaination to the last point (as you can also see in the tests, too):
With the new driver you should use 
`[BsonId(IdGenerator = typeof(Int32IdGenerator<StubInt32Entity>))]
`
With the legacy driver you should use
`[BsonId(IdGenerator = typeof(Int32IdGenerator))]`
